### PR TITLE
Fix file replace issue

### DIFF
--- a/backend/apps/neuranet/neuranetapp/lib/fileindexer.js
+++ b/backend/apps/neuranet/neuranetapp/lib/fileindexer.js
@@ -140,7 +140,7 @@ async function _handleFileEvent(message) {
 
     const _isDuplicateEvent = message => {
         const hashAlgo = crypto.createHash("md5"); 
-        hashAlgo.update(path.resolve(message.path||message.from)+message.id+message.org);
+        hashAlgo.update(path.resolve(message.path||message.from) + message.id + message.org + message.type);
         const hash = "_neuranet_fileindexer"+hashAlgo.digest("hex"); 
         if (!timed_expiry_cache.get(hash)) {timed_expiry_cache.set(hash, "present"); return false;}
         else return true;


### PR DESCRIPTION
Updated the _isDuplicateEvent logic to include the message.type when generating the deduplication hash. Previously, different event types (FILE_DELETED followed immediately by FILE_CREATED) on the same file path, ID, and org were incorrectly treated as duplicates and skipped. This caused only one of the events to be processed when both were valid and necessary.
