### PR TITLE
fix: Restrict AI app creation to admins only,  updated AI Workshop visibility logic and allow users to be AI app admins

### DIFF
--- a/frontend/apps/neuranet/i18n/i18n_en.mjs
+++ b/frontend/apps/neuranet/i18n/i18n_en.mjs
@@ -60,6 +60,7 @@ export const i18n = {
 "AIWorkshop_AIAppGenericError": "Error in AI application",
 "AIWorkshop_AIAppGenericSuccess": "Command succeeded",
 "AIWorkshop_AIAppAlreadyExists": "Error an app by that ID already exists",
+"AIWorkshop_NotAdmin": "You do not have required permissions. Please contact your administrator.",
 "AIWorkshop_ClickAppToEdit": "Click to edit",
 "AIWorkshop_KnowledgeBase": "AI Training"
 }

--- a/frontend/apps/neuranet/js/neuranetapp.mjs
+++ b/frontend/apps/neuranet/js/neuranetapp.mjs
@@ -37,7 +37,9 @@ async function _createdata(data) {
     let viewPath, aiendpoint, views, activeaiapp; delete data.showhome; delete data.shownotifications;
     const loginresponse = session.get(APP_CONSTANTS.LOGIN_RESPONSE), appsAllowed = [...(loginresponse?.apps||[])],
         isAdmin = session.get(APP_CONSTANTS.CURRENT_USERROLE).toString() == "admin";
-    if (isAdmin) appsAllowed.push({id: AI_WORKSHOP_VIEW, interface: {type: AI_WORKSHOP_VIEW,
+        const allaiApps = await apiman.rest(`${APP_CONSTANTS.API_PATH}/${API_GET_AIAPPS}`, "GET", {id:loginresponse.id, org:loginresponse.org, unpublished: true}, true);
+        const isAppAdmin =  (allaiApps.aiapps.some(app => app.admins?.includes(loginresponse.id)) || allaiApps.aiapps.some(app=> app.is_user_appadmin === true));
+    if (isAdmin || isAppAdmin) appsAllowed.push({id: AI_WORKSHOP_VIEW, interface: {type: AI_WORKSHOP_VIEW,
         label: await i18n.get(`ViewLabel_${AI_WORKSHOP_VIEW}`)}});  // admins can run AI workshops always
 
     const _getAppToForceLoadOrFalse = _ => session.get(APP_CONSTANTS.FORCE_LOAD_VIEW)?.toString()||false;


### PR DESCRIPTION
**Changes Made**

- Added logic in aiworkshop/main.mjs to check whether the current user is a admin or a user. For users, it verifies if they are listed as an admin on any AI app and displays only those apps accordingly.

- Introduced a restriction in aiworkshop/main.mjs to prevent users(app Admins) from creating new AI apps. If a user who is an app admin for an aiapp attempts to create an app, an error message is shown: "You do not have required permissions. Please contact your administrator." They can still train, delete, publish, and unpublish the apps they have admin access to.

- Updated neuranetapp.mjs to show the AI Workshop icon only if the user is a admin or an app admin for at least one AI app. 

- Testing screenshots have been attached in Mantis.

Mantis Link - https://tekmonks.mantishub.io/app/issues/5044?id=#c22124


